### PR TITLE
Use `pirates` for require hooks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 istanbul-lib-hook
 =================
 
+[![Beware: Pirates!](http://ariporad.link/pirates-badge)](https://github.com/ariporad/pirates "Beware: Pirates!")
 [![Build Status](https://travis-ci.org/istanbuljs/istanbul-lib-hook.svg?branch=master)](https://travis-ci.org/istanbuljs/istanbul-lib-hook)
 
 Hooks for require, vm and script used in istanbul

--- a/lib/hook.js
+++ b/lib/hook.js
@@ -2,34 +2,33 @@
  Copyright 2012-2015, Yahoo Inc.
  Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
-var path = require('path'),
-    Module = require('module'),
-    vm = require('vm'),
-    originalLoaders = {},
+var vm = require('vm'),
+    path = require('path'),
+    pirates = require('pirates'),
+    reverts = [],
     originalCreateScript = vm.createScript,
     originalRunInThisContext = vm.runInThisContext;
 
-function transformFn(matcher, transformer, verbose) {
+function shouldHook(matcher, filename) {
+    return typeof filename === 'string' && matcher(path.resolve(filename));
+}
+
+function transformFn(transformer, verbose) {
 
     return function (code, filename) {
-        var shouldHook = typeof filename === 'string' && matcher(path.resolve(filename)),
-            transformed,
+        var transformed,
             changed = false;
 
-        if (shouldHook) {
-            if (verbose) {
-                console.error('Module load hook: transform [' + filename + ']');
-            }
-            try {
-                transformed = transformer(code, filename);
-                changed = true;
-            } catch (ex) {
-                console.error('Transformation error for', filename, '; return original code');
-                console.error(ex.message || String(ex));
-                console.error(ex.stack);
-                transformed = code;
-            }
-        } else {
+        if (verbose) {
+            console.error('Module load hook: transform [' + filename + ']');
+        }
+        try {
+            transformed = transformer(code, filename);
+            changed = true;
+        } catch (ex) {
+            console.error('Transformation error for', filename, '; return original code');
+            console.error(ex.message || String(ex));
+            console.error(ex.stack);
             transformed = code;
         }
         return { code: transformed, changed: changed };
@@ -63,28 +62,21 @@ function unloadRequireCache(matcher) {
 function hookRequire(matcher, transformer, options) {
     options = options || {};
     var extensions,
-        fn = transformFn(matcher, transformer, options.verbose),
+        fn = transformFn(transformer, options.verbose),
         postLoadHook = options.postLoadHook &&
             typeof options.postLoadHook === 'function' ? options.postLoadHook : null;
 
     extensions = options.extensions || ['.js'];
 
-    extensions.forEach(function(ext){
-        if (!(ext in originalLoaders)) {
-            originalLoaders[ext] = Module._extensions[ext] || Module._extensions['.js'];
-        } 
-        Module._extensions[ext] = function (module, filename) {
-            var _compile = module._compile;
-            module._compile = function (code, filename) {
-                var ret = fn(code, filename);
-                if (postLoadHook) {
-                    postLoadHook(filename);
-                }
-                return _compile.call(module, ret.code, filename);
-            };
-            originalLoaders[ext](module, filename);
-        };
-    });
+    var revert = pirates.addHook(function(code, filename) {
+        var ret = fn(code, filename);
+        if (postLoadHook) {
+            postLoadHook(filename);
+        }
+        return ret.code;
+    }, { exts: extensions, matcher: matcher });
+
+    reverts.push(revert);
 }
 /**
  * unhook `require` to restore it to its original state.
@@ -92,9 +84,10 @@ function hookRequire(matcher, transformer, options) {
  * @static
  */
 function unhookRequire() {
-    Object.keys(originalLoaders).forEach(function(ext) {
-        Module._extensions[ext] = originalLoaders[ext];
+    reverts.forEach(function(revert) {
+        revert();
     });
+    reverts = [];
 }
 /**
  * hooks `vm.createScript` to return transformed code out of which a `Script` object will be created.
@@ -110,8 +103,11 @@ function unhookRequire() {
  */
 function hookCreateScript(matcher, transformer, opts) {
     opts = opts || {};
-    var fn = transformFn(matcher, transformer, opts.verbose);
+    var fn = transformFn(transformer, opts.verbose);
     vm.createScript = function (code, file) {
+        if (!shouldHook(matcher, file)) {
+            return originalCreateScript(code, file);
+        }
         var ret = fn(code, file);
         return originalCreateScript(ret.code, file);
     };
@@ -140,8 +136,11 @@ function unhookCreateScript() {
  */
 function hookRunInThisContext(matcher, transformer, opts) {
     opts = opts || {};
-    var fn = transformFn(matcher, transformer, opts.verbose);
+    var fn = transformFn(transformer, opts.verbose);
     vm.runInThisContext = function (code, file) {
+        if (!shouldHook(matcher, file)) {
+            return originalRunInThisContext(code, file);
+        }
         var ret = fn(code, file);
         return originalRunInThisContext(ret.code, file);
     };

--- a/package.json
+++ b/package.json
@@ -29,5 +29,8 @@
   "bugs": {
     "url": "https://github.com/istanbuljs/istanbul-lib-hook/issues"
   },
-  "homepage": "https://github.com/istanbuljs/istanbul-lib-hook#readme"
+  "homepage": "https://github.com/istanbuljs/istanbul-lib-hook#readme",
+  "dependencies": {
+    "pirates": "^2.0.0"
+  }
 }


### PR DESCRIPTION
Hi!

As discussed in various issues (mainly bcoe/nyc#70), this PR uses `pirates` to implement require hooks. Pirates takes care of hooking require, so we don't have to. This makes the various require-related functions in this module mostly wrappers, but useful none the less.

This change is completely transparent (a patch version bump), and all the tests still pass.
